### PR TITLE
Change order in navbar and connect buttons on home page to other pages

### DIFF
--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -3,8 +3,8 @@
         <mat-nav-list>
             <a mat-list-item [routerLink]="['/home']" (click)="layout.close()" routerLinkActive="nav-active" [routerLinkActiveOptions]="{exact: true}"><mat-icon>home</mat-icon>Home</a>
             <a mat-list-item [routerLink]="['/decks']" (click)="layout.close()" routerLinkActive="nav-active"><mat-icon>view_list</mat-icon>Decks</a>
-            <a mat-list-item [routerLink]="['/help']" (click)="layout.close()" routerLinkActive="nav-active"><mat-icon>help</mat-icon>Help</a>
             <a mat-list-item [routerLink]="['/card-list']" (click)="layout.close()" routerLinkActive="nav-active"><mat-icon>view_list</mat-icon>Cards</a>
+            <a mat-list-item [routerLink]="['/help']" (click)="layout.close()" routerLinkActive="nav-active"><mat-icon>help</mat-icon>Help</a>
         </mat-nav-list>
     </td-navigation-drawer>
     <td-layout-nav  toolbarTitle="SAGE" navigationRoute="/">

--- a/client/src/app/home/home.component.html
+++ b/client/src/app/home/home.component.html
@@ -9,10 +9,10 @@
         <button id="card-button" class="double-button" mat-raised-button color="primary" [routerLink]="['/card-list']">Cards</button>
     </div>
     <div id="deckButton" class="button-row">
-        <button id="deck-button" class="double-button" mat-raised-button color="primary">Decks</button>
+        <button id="deck-button" class="double-button" mat-raised-button color="primary" [routerLink]="['/card']">Decks</button>
     </div>
-    <div id ="settingButton" class="button-row">
-        <button id="setting-button" class="double-button" mat-raised-button color="primary">Settings</button>
+    <div id ="helpButton" class="button-row">
+        <button id="help-button" class="double-button" mat-raised-button color="primary" [routerLink]="['/help']">Help</button>
     </div>
 </div>
 


### PR DESCRIPTION
In the navbar help is now below cards.
The deck button on the home screen now connects to the deck
pageand the settings button is now the help button and connects
to the help screen.